### PR TITLE
Changed: Don't keep adding interval objects in popup

### DIFF
--- a/lib/popup.js
+++ b/lib/popup.js
@@ -14,7 +14,6 @@ export function keepPopupFocused(popupWindowRef) {
             clearInterval(intervalId);
         } else {
             popupWindowRef.focus();
-            keepPopupFocused(popupWindowRef);
         }
     }, 300);
 }


### PR DESCRIPTION
When calling keepPopupFocused, it would create an interval function,
and each time the interval ran (every 300ms) it would fork itself,
meaning in 10 seconds, we would have about 1 billion interval objects.

One is enough :)