### PR TITLE
chage paylinkid into more general paylink, also change routing to bff

### DIFF
--- a/lib/SDK.js
+++ b/lib/SDK.js
@@ -245,19 +245,19 @@ export default class SDK {
             });
     }
 
-    payment(paylinkId, redirectUri = null) {
+    payment(paylink, redirectUri = null) {
         if (this.options.popup) {
             if (this._lastPopupRef) {
                 this._lastPopupRef.close();
             }
-            const popupRef = openPopup(this.paymentUriBuilder.paymentPurchase(paylinkId, redirectUri), 'Purchase');
+            const popupRef = openPopup(this.paymentUriBuilder.paymentPurchase(paylink, redirectUri), 'Purchase');
             if (popupRef) {
                 this._lastPopupRef = popupRef;
                 keepPopupFocused(popupRef)
                 return popupRef;
             }
         }
-        window.location = this.paymentUriBuilder.paymentPurchase(paylinkId, redirectUri);
+        window.location = this.paymentUriBuilder.paymentPurchase(paylink, redirectUri);
         return window;
     }
 }

--- a/lib/uri.js
+++ b/lib/uri.js
@@ -141,10 +141,10 @@ class Builder {
         });
     }
 
-    paymentPurchase(paylinkId, redirectUri) {
-        return this._build('payment/purchase', {
+    paymentPurchase(paylink, redirectUri) {
+        return this._build('api/payment/purchase', {
             redirect_uri: redirectUri || this._defaultParams.redirect_uri,
-            paylink_id: paylinkId,
+            paylink,
         });
     }
 

--- a/test/uri.test.js
+++ b/test/uri.test.js
@@ -38,10 +38,10 @@ describe('uri', () => {
             });
             describe('returns the expected endpoint', () => {
                 it('to purchase flow with default redirect uri', () => {
-                    expect(builder.paymentPurchase(532)).to.equal('http://bff.spp.dev/payment/purchase?redirect_uri=http%3A%2F%2Flocalhost%3A4000&client_id=AAAxxEEE&paylink_id=532');
+                    expect(builder.paymentPurchase(532)).to.equal('http://bff.spp.dev/api/payment/purchase?redirect_uri=http%3A%2F%2Flocalhost%3A4000&client_id=AAAxxEEE&paylink=532');
                 });
                 it('to purchase flow with redirect uri', () => {
-                    expect(builder.paymentPurchase(532, 'http://localhost:5000')).to.equal('http://bff.spp.dev/payment/purchase?redirect_uri=http%3A%2F%2Flocalhost%3A5000&client_id=AAAxxEEE&paylink_id=532');
+                    expect(builder.paymentPurchase(532, 'http://localhost:5000')).to.equal('http://bff.spp.dev/api/payment/purchase?redirect_uri=http%3A%2F%2Flocalhost%3A5000&client_id=AAAxxEEE&paylink=532');
                 });
             });
         });


### PR DESCRIPTION
goal is to use paylink code instead of paylink id to identify paylink when starting purchase flow
also routing is adjusted to one in bff 